### PR TITLE
Fix Future.setHandler() deprecated warnings.

### DIFF
--- a/src/main/cpp/java_generator.cpp
+++ b/src/main/cpp/java_generator.cpp
@@ -1266,7 +1266,7 @@ static void PrintMethodHandlerClass(const ServiceDescriptor *service,
         // act like a future
         p->Print(
             *vars,
-            "      (io.vertx.core.Promise<$output_type$>) io.vertx.core.Promise.<$output_type$>promise().future().setHandler(ar -> {\n"
+            "      (io.vertx.core.Promise<$output_type$>) io.vertx.core.Promise.<$output_type$>promise().future().onComplete(ar -> {\n"
             "        if (ar.succeeded()) {\n"
             "          (($StreamObserver$<$output_type$>) responseObserver).onNext(ar.result());\n"
             "          responseObserver.onCompleted();\n"
@@ -1344,7 +1344,7 @@ static void PrintMethodHandlerClass(const ServiceDescriptor *service,
             *vars,
             "case $method_id_name$:\n"
             "  io.vertx.grpc.GrpcReadStream<$input_type$> request$idx$ = io.vertx.grpc.GrpcReadStream.<$input_type$>create();\n"
-            "  serviceImpl.$lower_method_name$(request$idx$, (io.vertx.core.Future<$output_type$>) io.vertx.core.Future.<$output_type$>future().setHandler(ar -> {\n"
+            "  serviceImpl.$lower_method_name$(request$idx$, (io.vertx.core.Future<$output_type$>) io.vertx.core.Future.<$output_type$>future().onComplete(ar -> {\n"
             "    if (ar.succeeded()) {\n"
             "      (($StreamObserver$<$output_type$>) responseObserver).onNext(ar.result());\n"
             "      responseObserver.onCompleted();\n"


### PR DESCRIPTION
```io.vertx.core.Future#setHandler``` was deprecated, so there are so many warnings in gRPC genarated codes.

I replace ```io.vertx.core.Future#setHandler``` with ```io.vertx.core.Future#onComplete```, these warnings will disappear.